### PR TITLE
Add awx_host_ssl_certificate_key to specify separate private key (#21)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ awx_host_ssl_port: 443
 # Optional SSL stuff, the files are copied from the server you run ansible from.
 # (ansible copy src)
 # awx_host_ssl_certificate: /etc/cockpit/ws-certs.d/0-self-signed.cert
+# awx_host_ssl_certificate_key: /etc/pki/tls/private/keyfile.pem
 # awx_host_ssl_ca_trust_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 #

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,6 +106,14 @@
       owner: '1000'
     when: awx_host_ssl_certificate is defined
 
+  - name: copy ssl key certificate
+    copy:
+      src: "{{ awx_host_ssl_certificate_key }}"
+      dest: "{{ awx_podman_dir }}/awxweb_key.pem"
+      mode: '0600'
+      owner: '1000'
+    when: awx_host_ssl_certificate_key is defined
+
   - name: template ngnix.conf
     template:
       src: nginx.conf.j2

--- a/templates/awx.yml.j2
+++ b/templates/awx.yml.j2
@@ -69,6 +69,12 @@ spec:
       path: {{ awx_podman_dir }}/awxweb.pem
       type: File
 {% endif %}
+{% if awx_host_ssl_certificate_key is defined %}
+  - name: ssl_certificate_key
+    hostPath:
+      path: {{ awx_podman_dir }}/awxweb_key.pem
+      type: File
+{% endif %}
   containers:
   #
   # postgres container
@@ -156,6 +162,11 @@ spec:
       name: ssl_certificate
       readOnly: true
 {% endif %}
+{% if awx_host_ssl_certificate_key is defined %}
+    - mountPath: /etc/nginx/awxweb_key.pem:z
+      name: ssl_certificate_key
+      readOnly: true
+{% endif %}
     ports:
       - containerPort: 8052
         hostPort: {{ awx_host_port }}
@@ -228,6 +239,11 @@ spec:
 {% if awx_host_ssl_certificate is defined %}
     - mountPath: /etc/nginx/awxweb.pem:z
       name: ssl_certificate
+      readOnly: true
+{% endif %}
+{% if awx_host_ssl_certificate_key is defined %}
+    - mountPath: /etc/nginx/awxweb_key.pem:z
+      name: ssl_certificate_key
       readOnly: true
 {% endif %}
   #

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -51,8 +51,12 @@ http {
         listen 8053 ssl;
 
         ssl_certificate /etc/nginx/awxweb.pem;
+          {% if awx_host_ssl_certificate_key is defined %}
+        ssl_certificate_key /etc/nginx/awxweb_key.pem;
+          {% else %}
         ssl_certificate_key /etc/nginx/awxweb.pem;
-        {% else %}
+          {% endif %}
+	{% else %}
         listen 8052 default_server;
         {% endif %}
 


### PR DESCRIPTION
* Added awx_host_ssl_certificate_key to specify separate private key

* Update nginx.conf.j2

* Update nginx.conf.j2

changed condition on ssl_certificate_key variable to reduce duplicate lines

* Update nginx.conf.j2

Wrong semicolon position

* Reverted line 50 to original form